### PR TITLE
Fix crash when scanning invalid PE

### DIFF
--- a/Pando.py
+++ b/Pando.py
@@ -835,8 +835,11 @@ def main():
             )
             progress.advance(task, advance=20)
             progress.update(task, description="Analyzing resources...")
-            pe = pefile.PE(file_to_scan)
-            resources = anares(pe)
+            try:
+                pe = pefile.PE(file_to_scan)
+                resources = anares(pe)
+            except pefile.PEFormatError:
+                resources = []
             progress.advance(task, advance=20)
             progress.update(task, description="Generating final report...")
             progress.advance(task, advance=10)


### PR DESCRIPTION
## Summary
- gracefully handle invalid PE files in the resource analysis step

## Testing
- `python -m py_compile Pando.py`

